### PR TITLE
Make keyboard shortcut and arrow icons cross-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Searches are performed as you type, and there are regex options to further filte
 #### Usage
 
 * `Ctrl + Shift + F` or extension button to launch search dialog
-* `Ctrl + 🠆` or `🠆` button to go to next match
-* `Ctrl + 🠄` or `🠄` button to go to previous match
+* `Ctrl + →` or `→` button to go to next match
+* `Ctrl + ←` or `←` button to go to previous match
 * `Ctrl + Del` or `×` button to clear current search text and results
 
 #### Contributing

--- a/html/search-box.html
+++ b/html/search-box.html
@@ -47,9 +47,9 @@
         </form>
 
         <div class="button-bar">
-            <button id="previous" class="text-button" title="Previous match (Ctrl + 🡐)">🡐</button>
+            <button id="previous" class="text-button" title="Previous match (Ctrl + ←)">←</button>
 
-            <button id="next" class="text-button" title="Next match (Ctrl + 🡒)">🡒</button>
+            <button id="next" class="text-button" title="Next match (Ctrl + →)">→</button>
 
             <div class="align-right">
                 <button id="clear" class="text-button" title="Clear results (Ctrl + Del)">×</button>

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "description": "A more advanced find on page tool",
     "version": "1.2",
     "offline_enabled": true,
-    "author": "hughjdavey@github.com",
+    "author": "hughjdavey@github.com | contributors: [ edwardprentice@github.com ]",
 
     "permissions": [
         "activeTab"
@@ -47,7 +47,8 @@
         },
         "_execute_browser_action": {
             "suggested_key": {
-                "default": "Ctrl+Shift+F"
+                "default": "Ctrl+Shift+F",
+                "mac": "MacCtrl+Shift+F"
             }
         }
     }


### PR DESCRIPTION
The arrows for me weren't rendering on Chrome on OSX 10.11.6.

I've changed the arrows to basic unicode that I hope is more portable (ie. still renders in Windows).